### PR TITLE
Change docs xml object to have dictionary name 

### DIFF
--- a/docs/odxml.md
+++ b/docs/odxml.md
@@ -31,7 +31,7 @@ Now let's break this down.
 
 ---
 
-## `<definition>`
+## `<dictionary>`
 
 Dictionary nodes occur at the base of all source files and will not compile without one. ODict looks for these nodes by default when compiling.
 


### PR DESCRIPTION
I think based on the context it'd be `<dictionary>` instead of `<definition>`.

Just a simple typo fix when reading through the docs! If this isn't needed, no worries 👍 