### PR TITLE
Fixing Maven deployment

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -6,6 +6,12 @@ load("//bazel:odict_deps.bzl", "odict_deps")
 
 odict_deps()
 
+load("@rules_jvm_external//:repositories.bzl", "rules_jvm_external_deps")
+rules_jvm_external_deps()
+
+load("@rules_jvm_external//:setup.bzl", "rules_jvm_external_setup")
+rules_jvm_external_setup()
+
 load("//bazel:odict_extra_deps.bzl", "odict_extra_deps")
 
 odict_extra_deps()

--- a/bazel/odict_deps.bzl
+++ b/bazel/odict_deps.bzl
@@ -59,3 +59,11 @@ def odict_deps():
         patch_args = ["-p1"],
         patches = ["@odict//bazel:flatbuffers_1_12_0.patch"],
     )
+
+    maybe(
+        http_archive,
+        name = "rules_jvm_external",
+        strip_prefix = "rules_jvm_external-%s" % RULES_JVM_EXTERNAL_TAG,
+        sha256 = RULES_JVM_EXTERNAL_SHA,
+        url = "https://github.com/bazelbuild/rules_jvm_external/archive/%s.zip" % RULES_JVM_EXTERNAL_TAG,
+    )


### PR DESCRIPTION
## Description
This PR fixes the Maven deployment procedure introduced in #24, but which was broken in commit 030a1d99037e01d49cfd991165d01559b2dfc061 simply because `rules_jvm_external` needs more dependencies to actually run the Maven deployment.