### PR TITLE
fix(*): fixes splitting and return 2D array from CLI

### DIFF
--- a/cli/lookup.go
+++ b/cli/lookup.go
@@ -20,8 +20,10 @@ func lookup(c *cli.Context) error {
 	t(c, func() {
 		dict := odict.ReadDictionaryFromPath(inputFile)
 		entries := dict.Lookup(queries, split)
-		representable := odict.Map(entries, func(entry odict.Entry) odict.EntryRepresentable {
-			return entry.AsRepresentable()
+		representable := odict.Map(entries, func(e []odict.Entry) []odict.EntryRepresentable {
+			return odict.Map(e, func(entry odict.Entry) odict.EntryRepresentable {
+				return entry.AsRepresentable()
+			})
 		})
 
 		fmt.Println(odict.JSON(representable))

--- a/go/lookup.go
+++ b/go/lookup.go
@@ -24,8 +24,8 @@ func (dict *Dictionary) lookup(query string, fallback string, split int) []Entry
 	return entries
 }
 
-func (dict *Dictionary) Lookup(queries []string, split int) []Entry {
-	entries := []Entry{}
+func (dict *Dictionary) Lookup(queries []string, split int) [][]Entry {
+	entries := [][]Entry{}
 	r, _ := regexp.Compile(`\((.+)\)$`)
 
 	for _, query := range queries {
@@ -37,7 +37,7 @@ func (dict *Dictionary) Lookup(queries []string, split int) []Entry {
 			fallback = match[0][1]
 		}
 
-		entries = append(entries, dict.lookup(strings.Trim(query, " "), fallback, split)...)
+		entries = append(entries, dict.lookup(strings.Trim(query, " "), fallback, split))
 	}
 
 	return entries

--- a/go/lookup_test.go
+++ b/go/lookup_test.go
@@ -13,8 +13,10 @@ func TestLookup(t *testing.T) {
 	entries := dict.Lookup([]string{"run", "poo"}, 0)
 
 	assert.Equal(t, 2, len(entries))
-	assert.Equal(t, "run", string(entries[0].Term()))
-	assert.Equal(t, "poo", string(entries[1].Term()))
+	assert.Equal(t, 1, len(entries[0]))
+	assert.Equal(t, 1, len(entries[1]))
+	assert.Equal(t, "run", string(entries[0][0].Term()))
+	assert.Equal(t, "poo", string(entries[1][0].Term()))
 
 	CleanupTest()
 }
@@ -25,9 +27,10 @@ func TestLookupSplitting(t *testing.T) {
 	dict := ReadDictionaryFromPath("../examples/example1.odict")
 	entries := dict.Lookup([]string{"catdog"}, 2)
 
-	assert.Equal(t, 2, len(entries))
-	assert.Equal(t, "cat", string(entries[0].Term()))
-	assert.Equal(t, "dog", string(entries[1].Term()))
+	assert.Equal(t, 1, len(entries))
+	assert.Equal(t, 2, len(entries[0]))
+	assert.Equal(t, "cat", string(entries[0][0].Term()))
+	assert.Equal(t, "dog", string(entries[0][1].Term()))
 
 	CleanupTest()
 }
@@ -39,12 +42,12 @@ func TestFallbacks(t *testing.T) {
 	entries := dict.Lookup([]string{"catdog(run)"}, 2)
 
 	assert.Equal(t, 1, len(entries))
-	assert.Equal(t, "run", string(entries[0].Term()))
+	assert.Equal(t, "run", string(entries[0][0].Term()))
 
 	entries = dict.Lookup([]string{"(run)"}, 2)
 
 	assert.Equal(t, 1, len(entries))
-	assert.Equal(t, "run", string(entries[0].Term()))
+	assert.Equal(t, "run", string(entries[0][0].Term()))
 
 	CleanupTest()
 }

--- a/go/split.go
+++ b/go/split.go
@@ -15,13 +15,17 @@ func (dict *Dictionary) Split(query string, threshold int) []Entry {
 		substr := query[start:end]
 		found = dict.EntryByKey(&entry, substr)
 
-		if found && len(substr) >= threshold {
+		if found {
 			entries = append(entries, entry)
+		}
+
+		if found || len(substr) <= threshold {
 			start = end
 			end = len(query)
 		} else {
 			end--
 		}
+
 	}
 
 	return entries

--- a/go/split_test.go
+++ b/go/split_test.go
@@ -19,3 +19,17 @@ func TestSplit(t *testing.T) {
 
 	CleanupTest()
 }
+
+func TestSplitWithNumbers(t *testing.T) {
+	CompileDictionary("../examples/example1.xml", "../examples/example1.odict")
+
+	dict1 := ReadDictionaryFromPath("../examples/example1.odict")
+
+	entries := dict1.Split("2cat8dog", 1)
+
+	assert.Equal(t, 2, len(entries))
+	assert.Equal(t, "cat", string(entries[0].Term()))
+	assert.Equal(t, "dog", string(entries[1].Term()))
+
+	CleanupTest()
+}

--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "theopendictionary",
-  "version": "0.0.2-rc3",
+  "version": "0.0.2-rc5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "theopendictionary",
-      "version": "0.0.2-rc3",
+      "version": "0.0.2-rc5",
       "license": "ISC",
       "devDependencies": {
         "@swc/cli": "^0.1.57",

--- a/js/src/dictionary.ts
+++ b/js/src/dictionary.ts
@@ -114,19 +114,13 @@ class Dictionary {
 
     const { split = this.options.defaultSplitThreshold } = options;
 
-    return Promise.all(
-      queries.map(queryToString).map(async (query) => {
-        const raw = await exec(
-          "lookup",
-          "-s",
-          split.toString(),
-          this.path,
-          query
-        );
-
-        return JSON.parse(raw);
-      })
-    );
+    return exec(
+      "lookup",
+      "-s",
+      split.toString(),
+      this.path,
+      ...queries.map(queryToString)
+    ).then(JSON.parse);
   }
 
   /**

--- a/python/odict/test_odict.py
+++ b/python/odict/test_odict.py
@@ -31,5 +31,5 @@ def test_write_lookup_dictionary():
     expected = '[{"term":"hello","etymologies":[{"id":"0","usages":{"v":{"pos":"v","definitions":["hello world"]}}}]}]'
     
     assert len(output) == 1, "there should only be one result"
-    assert output[0].get("term") == "hello", "json should be %s, received: %s" % (expected, json)
+    assert output[0][0].get("term") == "hello", "json should be %s, received: %s" % (expected, json)
     


### PR DESCRIPTION
This PR fixes word splitting in the event the first subtoken can't be found (like in 8月, "8" might not be in a Chinese dictionary, but 月 should be). This PR also returns a 2D array (instead of the previous 1D) from the CLI's `lookup` command to account for subtokens, so now all definitions will be contained in a 2D array.