### PR TITLE
Fix - "VALUES: rowvalues #1: rowvalue #2: types.MDString has no SQL representation" Error

### DIFF
--- a/lib/dump/sql.go
+++ b/lib/dump/sql.go
@@ -151,7 +151,7 @@ func sqlInsertEtymologies(sqlDialect SqlDialect, etymologies []types.EtymologyRe
 		insertQuery := sq.
 			InsertInto(ety).
 			Columns(ety.ID, ety.DESCRIPTION, ety.ENTRY_ID).
-			Values(sq.Literal(sqlEtymologyId), sq.Literal(etymology.Description), sq.Literal(sqlEntryId))
+			Values(sq.Literal(sqlEtymologyId), sq.Literal(etymology.Description.String()), sq.Literal(sqlEntryId))
 
 		ety_query, _, err := sq.ToSQL(sqlDialect, insertQuery, nil)
 
@@ -249,8 +249,8 @@ func sqlInsertDefinitions(sqlDialect SqlDialect, definitions []types.DefinitionR
 
 		insertQuery := sq.
 			InsertInto(def).
-			Columns(def.ID, def.TEXT, def.SENSE_ID, def.GROUP_ID).
-			Values(sq.Literal(sqlDefinitionId), sq.Literal(definition.Value), sq.Literal(sqlSenseId), sq.Literal(sqlGroupId))
+			Columns(def.ID, def.VALUE, def.SENSE_ID, def.GROUP_ID).
+			Values(sq.Literal(sqlDefinitionId), sq.Literal(definition.Value.String()), sq.Literal(sqlSenseId), sq.Literal(sqlGroupId))
 
 		def_query, _, err := sq.ToSQL(sqlDialect, insertQuery, nil)
 

--- a/lib/dump/types.go
+++ b/lib/dump/types.go
@@ -40,7 +40,7 @@ type GROUPS struct {
 type DEFINITIONS struct {
 	sq.TableStruct
 	ID       sq.NumberField `ddl:"type=BIGINT primarykey auto_increment autoincrement identity"`
-	TEXT     sq.StringField `ddl:"notnull"`
+	VALUE    sq.StringField `ddl:"notnull"`
 	SENSE_ID sq.NumberField `ddl:"type=BIGINT references=senses.id"`
 	GROUP_ID sq.NumberField `ddl:"type=BIGINT references=groups.id"`
 }


### PR DESCRIPTION
These changes will allow us to dump odict files to SQL format by fixing the issue with markdown formatted values in `Description`s and `Definition` `Value`s.

I think this will be one step further to getting a docker-compose file for our web repo! This closes #519 

## Steps to reproduce

- Compile `examples/example2.xml` to odict format
- Dump said odict file to SQL `go run odict.go d -f postgres examples/example2.odict examples/output.sql`
- See error in terminal
