### PR TITLE
fix(pos): fix mismatch between buffer strings and POS tags

### DIFF
--- a/cli/go.mod
+++ b/cli/go.mod
@@ -42,7 +42,7 @@ require (
 	github.com/golang/geo v0.0.0-20210211234256-740aa86cb551 // indirect
 	github.com/golang/protobuf v1.3.2 // indirect
 	github.com/golang/snappy v0.0.4 // indirect
-	github.com/gomarkdown/markdown v0.0.0-20231115200524-a660076da3fd // indirect
+	github.com/gomarkdown/markdown v0.0.0-20231222211730-1d6d20845b47 // indirect
 	github.com/imdario/mergo v0.3.16 // indirect
 	github.com/json-iterator/go v0.0.0-20171115153421-f7279a603ede // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect

--- a/cli/go.sum
+++ b/cli/go.sum
@@ -68,8 +68,7 @@ github.com/golang/protobuf v1.3.2 h1:6nsPYzhq5kReh6QImI3k5qWzO4PEbvbIW2cwSfR/6xs
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/snappy v0.0.4 h1:yAGX7huGHXlcLOEtBnF4w7FQwA26wojNCwOYAEhLjQM=
 github.com/golang/snappy v0.0.4/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
-github.com/gomarkdown/markdown v0.0.0-20231115200524-a660076da3fd h1:PppHBegd3uPZ3Y/Iax/2mlCFJm1w4Qf/zP1MdW4ju2o=
-github.com/gomarkdown/markdown v0.0.0-20231115200524-a660076da3fd/go.mod h1:JDGcbDT52eL4fju3sZ4TeHGsQwhG9nbDV21aMyhwPoA=
+github.com/gomarkdown/markdown v0.0.0-20231222211730-1d6d20845b47 h1:k4Tw0nt6lwro3Uin8eqoET7MDA4JnT8YgbCjc/g5E3k=
 github.com/google/flatbuffers v23.5.26+incompatible h1:M9dgRyhJemaM4Sw8+66GHBu8ioaQmyPLg1b8VwK5WJg=
 github.com/google/flatbuffers v23.5.26+incompatible/go.mod h1:1AeVuKshWv4vARoZatz6mlQ0JxURH0Kv5+zNeJKJCa8=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=

--- a/lib/core/go.mod
+++ b/lib/core/go.mod
@@ -15,7 +15,7 @@ require (
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/gomarkdown/markdown v0.0.0-20231115200524-a660076da3fd // indirect
+	github.com/gomarkdown/markdown v0.0.0-20231222211730-1d6d20845b47 // indirect
 	github.com/google/flatbuffers v23.5.26+incompatible // indirect
 	github.com/imdario/mergo v0.3.16 // indirect
 	github.com/kr/text v0.1.0 // indirect

--- a/lib/core/go.sum
+++ b/lib/core/go.sum
@@ -10,8 +10,7 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/golang/snappy v0.0.4 h1:yAGX7huGHXlcLOEtBnF4w7FQwA26wojNCwOYAEhLjQM=
 github.com/golang/snappy v0.0.4/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
-github.com/gomarkdown/markdown v0.0.0-20231115200524-a660076da3fd h1:PppHBegd3uPZ3Y/Iax/2mlCFJm1w4Qf/zP1MdW4ju2o=
-github.com/gomarkdown/markdown v0.0.0-20231115200524-a660076da3fd/go.mod h1:JDGcbDT52eL4fju3sZ4TeHGsQwhG9nbDV21aMyhwPoA=
+github.com/gomarkdown/markdown v0.0.0-20231222211730-1d6d20845b47 h1:k4Tw0nt6lwro3Uin8eqoET7MDA4JnT8YgbCjc/g5E3k=
 github.com/google/flatbuffers v23.5.26+incompatible h1:M9dgRyhJemaM4Sw8+66GHBu8ioaQmyPLg1b8VwK5WJg=
 github.com/google/flatbuffers v23.5.26+incompatible/go.mod h1:1AeVuKshWv4vARoZatz6mlQ0JxURH0Kv5+zNeJKJCa8=
 github.com/google/uuid v1.5.0 h1:1p67kYwdtXjb0gL0BPiP1Av9wiZPo5A8z2cWkTZ+eyU=

--- a/lib/search/go.mod
+++ b/lib/search/go.mod
@@ -35,7 +35,7 @@ require (
 	github.com/golang/geo v0.0.0-20210211234256-740aa86cb551 // indirect
 	github.com/golang/protobuf v1.3.2 // indirect
 	github.com/golang/snappy v0.0.4 // indirect
-	github.com/gomarkdown/markdown v0.0.0-20231115200524-a660076da3fd // indirect
+	github.com/gomarkdown/markdown v0.0.0-20231222211730-1d6d20845b47 // indirect
 	github.com/google/flatbuffers v23.5.26+incompatible // indirect
 	github.com/google/uuid v1.5.0 // indirect
 	github.com/imdario/mergo v0.3.16 // indirect

--- a/lib/search/go.sum
+++ b/lib/search/go.sum
@@ -53,7 +53,7 @@ github.com/golang/protobuf v1.3.2 h1:6nsPYzhq5kReh6QImI3k5qWzO4PEbvbIW2cwSfR/6xs
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/snappy v0.0.4 h1:yAGX7huGHXlcLOEtBnF4w7FQwA26wojNCwOYAEhLjQM=
 github.com/golang/snappy v0.0.4/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
-github.com/gomarkdown/markdown v0.0.0-20231115200524-a660076da3fd h1:PppHBegd3uPZ3Y/Iax/2mlCFJm1w4Qf/zP1MdW4ju2o=
+github.com/gomarkdown/markdown v0.0.0-20231222211730-1d6d20845b47 h1:k4Tw0nt6lwro3Uin8eqoET7MDA4JnT8YgbCjc/g5E3k=
 github.com/google/flatbuffers v23.5.26+incompatible h1:M9dgRyhJemaM4Sw8+66GHBu8ioaQmyPLg1b8VwK5WJg=
 github.com/google/flatbuffers v23.5.26+incompatible/go.mod h1:1AeVuKshWv4vARoZatz6mlQ0JxURH0Kv5+zNeJKJCa8=
 github.com/google/gofuzz v1.2.0 h1:xRy4A+RhZaiKjJ1bPfwQ8sedCA+YS2YcCHW6ec7JMi0=

--- a/lib/types/etymology.go
+++ b/lib/types/etymology.go
@@ -49,7 +49,7 @@ func (ety *EtymologyRepresentable) buildSenseVector(builder *flatbuffers.Builder
 	keys := make([]string, 0, senseCount)
 
 	for key := range senses {
-		keys = append(keys, key.Tag)
+		keys = append(keys, key.Tag())
 	}
 
 	sort.Strings(keys)

--- a/lib/types/go.mod
+++ b/lib/types/go.mod
@@ -12,7 +12,7 @@ require (
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/gomarkdown/markdown v0.0.0-20231115200524-a660076da3fd // indirect
+	github.com/gomarkdown/markdown v0.0.0-20231222211730-1d6d20845b47 // indirect
 	github.com/kr/text v0.1.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	golang.org/x/exp v0.0.0-20220303212507-bbda1eaf7a17 // indirect

--- a/lib/types/go.sum
+++ b/lib/types/go.sum
@@ -2,8 +2,7 @@ github.com/TheOpenDictionary/odict/lib/utils v0.0.0-20231201204918-056ce8487757 
 github.com/TheOpenDictionary/odict/lib/utils v0.0.0-20231201204918-056ce8487757/go.mod h1:PpECSsE6EVzk6sV4eFTNs3cj9eR2vtOosDdsb7EtLlI=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/gomarkdown/markdown v0.0.0-20231115200524-a660076da3fd h1:PppHBegd3uPZ3Y/Iax/2mlCFJm1w4Qf/zP1MdW4ju2o=
-github.com/gomarkdown/markdown v0.0.0-20231115200524-a660076da3fd/go.mod h1:JDGcbDT52eL4fju3sZ4TeHGsQwhG9nbDV21aMyhwPoA=
+github.com/gomarkdown/markdown v0.0.0-20231222211730-1d6d20845b47 h1:k4Tw0nt6lwro3Uin8eqoET7MDA4JnT8YgbCjc/g5E3k=
 github.com/google/flatbuffers v23.5.26+incompatible h1:M9dgRyhJemaM4Sw8+66GHBu8ioaQmyPLg1b8VwK5WJg=
 github.com/google/flatbuffers v23.5.26+incompatible/go.mod h1:1AeVuKshWv4vARoZatz6mlQ0JxURH0Kv5+zNeJKJCa8=
 github.com/imdario/mergo v0.3.16 h1:wwQJbIsHYGMUyLSPrEq1CT16AhnhNJQ51+4fdHUnCl4=

--- a/lib/types/pos.go
+++ b/lib/types/pos.go
@@ -2,136 +2,140 @@ package types
 
 import (
 	"encoding/xml"
+	"strings"
 )
 
 type PartOfSpeech struct {
-	Tag   string
 	Label string
 	Buf   POS
+}
+
+func (pos PartOfSpeech) Tag() string {
+	return strings.ReplaceAll(pos.Buf.String(), "_", "-")
 }
 
 /* -------------------------------------------------------------------------- */
 /*                            Japanese-specific POS                           */
 /* -------------------------------------------------------------------------- */
 
-var AdjectivalPreNoun = PartOfSpeech{Tag: "adj-pn", Buf: POSadj_pn, Label: "pre-noun adjectival (rentaishi)"}
-var AdjectiveKari = PartOfSpeech{Tag: "adj-kari", Buf: POSadj_kari, Label: "'kari' adjective (archaic)"}
-var AdjectiveKu = PartOfSpeech{Tag: "adj-ku", Buf: POSadj_ku, Label: "'ku' adjective (archaic)"}
-var AdjectiveNari = PartOfSpeech{Tag: "adj-nari", Buf: POSadj_nari, Label: "archaic/formal form of na-adjective"}
-var AdjectiveNoun = PartOfSpeech{Tag: "adj-na", Buf: POSadj_na, Label: "adjectival nouns or quasi-adjectives (keiyodoshi)"}
-var AdjectiveShiku = PartOfSpeech{Tag: "adj-shiku", Buf: POSadj_shiku, Label: "'shiku' adjective (archaic)"}
-var AdjectiveTaru = PartOfSpeech{Tag: "adj-t", Buf: POSadj_t, Label: "'taru' adjective"}
-var AdjectiveYoiIi = PartOfSpeech{Tag: "adj-ix", Buf: POSadj_ix, Label: "adjective (keiyoushi) - yoi/ii class"}
-var AdverbialNoun = PartOfSpeech{Tag: "n-adv", Buf: POSn_adv, Label: "adverbial noun (fukushitekimeishi)"}
-var AdverbTo = PartOfSpeech{Tag: "adv-to", Buf: POSadv_to, Label: "adverb taking the 'to' particle"}
-var NounNo = PartOfSpeech{Tag: "adj-no", Buf: POSadj_no, Label: "nouns which may take the genitive case particle 'no'"}
-var NounPrefix = PartOfSpeech{Tag: "n-pref", Buf: POSn_pref, Label: "noun, used as a prefix"}
-var NounSuffix = PartOfSpeech{Tag: "n-suf", Buf: POSn_suf, Label: "noun, used as a suffix"}
-var NounTemporal = PartOfSpeech{Tag: "n-t", Buf: POSn_t, Label: "noun (temporal) (jisoumeishi)"}
-var NounVerbPrenominal = PartOfSpeech{Tag: "adj-f", Buf: POSadj_f, Label: "noun or verb acting prenominally"}
-var VerbGodanBu = PartOfSpeech{Tag: "v5b", Buf: POSv5b, Label: "Godan verb with 'bu' ending"}
-var VerbGodanGu = PartOfSpeech{Tag: "v5g", Buf: POSv5g, Label: "Godan verb with 'gu' ending"}
-var VerbGodanKu = PartOfSpeech{Tag: "v5k", Buf: POSv5k, Label: "Godan verb with 'ku' ending"}
-var VerbGodanMu = PartOfSpeech{Tag: "v5m", Buf: POSv5m, Label: "Godan verb with 'mu' ending"}
-var VerbGodanNu = PartOfSpeech{Tag: "v5n", Buf: POSv5n, Label: "Godan verb with 'nu' ending"}
-var VerbGodanRu = PartOfSpeech{Tag: "v5r", Buf: POSv5r, Label: "Godan verb with 'ru' ending"}
-var VerbGodanRuIrregular = PartOfSpeech{Tag: "v5r-i", Buf: POSv5r_i, Label: "Godan verb with 'ru' ending (irregular verb)"}
-var VerbGodanSpecialAru = PartOfSpeech{Tag: "v5aru", Buf: POSv5aru, Label: "Godan verb - -aru special class"}
-var VerbGodanSpecialIkuYuku = PartOfSpeech{Tag: "v5k-s", Buf: POSv5k_s, Label: "Godan verb - Iku/Yuku special class"}
-var VerbGodanSu = PartOfSpeech{Tag: "v5s", Buf: POSv5s, Label: "Godan verb with 'su' ending"}
-var VerbGodanTsu = PartOfSpeech{Tag: "v5t", Buf: POSv5t, Label: "Godan verb with 'tsu' ending"}
-var VerbGodanU = PartOfSpeech{Tag: "v5u", Buf: POSv5u, Label: "Godan verb with 'u' ending"}
-var VerbGodanUruOldVerbOldFormOfEru = PartOfSpeech{Tag: "v5uru", Buf: POSv5uru, Label: "Godan verb - Uru old class verb (old form of Eru)"}
-var VerbGodanUSpecial = PartOfSpeech{Tag: "v5u-s", Buf: POSv5u_s, Label: "Godan verb with 'u' ending (special class)"}
-var VerbIchidan = PartOfSpeech{Tag: "v1", Buf: POSv1, Label: "Ichidan verb"}
-var VerbIchidanSpecial = PartOfSpeech{Tag: "v1-s", Buf: POSv1_s, Label: "Ichidan verb - kureru special class"}
-var VerbIchidanZuru = PartOfSpeech{Tag: "vz", Buf: POSvz, Label: "Ichidan verb - zuru verb (alternative form of -jiru verbs)"}
-var VerbKuruSpecial = PartOfSpeech{Tag: "vk", Buf: POSvk, Label: "Kuru verb - special class"}
-var VerbNidanBuLower = PartOfSpeech{Tag: "v2b-s", Buf: POSv2b_s, Label: "Nidan verb (lower class) with 'bu' ending (archaic)"}
-var VerbNidanBuUpper = PartOfSpeech{Tag: "v2b-k", Buf: POSv2b_k, Label: "Nidan verb (upper class) with 'bu' ending (archaic)"}
-var VerbNidanDzuLower = PartOfSpeech{Tag: "v2d-s", Buf: POSv2d_s, Label: "Nidan verb (lower class) with 'dzu' ending (archaic)"}
-var VerbNidanDzuUpper = PartOfSpeech{Tag: "v2d-k", Buf: POSv2d_k, Label: "Nidan verb (upper class) with 'dzu' ending (archaic)"}
-var VerbNidanGuLower = PartOfSpeech{Tag: "v2g-s", Buf: POSv2g_s, Label: "Nidan verb (lower class) with 'gu' ending (archaic)"}
-var VerbNidanGuUpper = PartOfSpeech{Tag: "v2g-k", Buf: POSv2g_k, Label: "Nidan verb (upper class) with 'gu' ending (archaic)"}
-var VerbNidanHuFuLower = PartOfSpeech{Tag: "v2h-s", Buf: POSv2h_s, Label: "Nidan verb (lower class) with 'hu/fu' ending (archaic)"}
-var VerbNidanHuFuUpper = PartOfSpeech{Tag: "v2h-k", Buf: POSv2h_k, Label: "Nidan verb (upper class) with 'hu/fu' ending (archaic)"}
-var VerbNidanKuLower = PartOfSpeech{Tag: "v2k-s", Buf: POSv2k_s, Label: "Nidan verb (lower class) with 'ku' ending (archaic)"}
-var VerbNidanKuUpper = PartOfSpeech{Tag: "v2k-k", Buf: POSv2k_k, Label: "Nidan verb (upper class) with 'ku' ending (archaic)"}
-var VerbNidanMuLower = PartOfSpeech{Tag: "v2m-s", Buf: POSv2m_s, Label: "Nidan verb (lower class) with 'mu' ending (archaic)"}
-var VerbNidanMuUpper = PartOfSpeech{Tag: "v2m-k", Buf: POSv2m_k, Label: "Nidan verb (upper class) with 'mu' ending (archaic)"}
-var VerbNidanNuLower = PartOfSpeech{Tag: "v2n-s", Buf: POSv2n_s, Label: "Nidan verb (lower class) with 'nu' ending (archaic)"}
-var VerbNidanRuLower = PartOfSpeech{Tag: "v2r-s", Buf: POSv2r_s, Label: "Nidan verb (lower class) with 'ru' ending (archaic)"}
-var VerbNidanRuUpper = PartOfSpeech{Tag: "v2r-k", Buf: POSv2r_k, Label: "Nidan verb (upper class) with 'ru' ending (archaic)"}
-var VerbNidanSuLower = PartOfSpeech{Tag: "v2s-s", Buf: POSv2s_s, Label: "Nidan verb (lower class) with 'su' ending (archaic)"}
-var VerbNidanTsuLower = PartOfSpeech{Tag: "v2t-s", Buf: POSv2t_s, Label: "Nidan verb (lower class) with 'tsu' ending (archaic)"}
-var VerbNidanTsuUpper = PartOfSpeech{Tag: "v2t-k", Buf: POSv2t_k, Label: "Nidan verb (upper class) with 'tsu' ending (archaic)"}
-var VerbNidanU = PartOfSpeech{Tag: "v2a-s", Buf: POSv2a_s, Label: "Nidan verb with 'u' ending (archaic)"}
-var VerbNidanUWeLower = PartOfSpeech{Tag: "v2w-s", Buf: POSv2w_s, Label: "Nidan verb (lower class) with 'u' ending and 'we' conjugation (archaic)"}
-var VerbNidanYuLower = PartOfSpeech{Tag: "v2y-s", Buf: POSv2y_s, Label: "Nidan verb (lower class) with 'yu' ending (archaic)"}
-var VerbNidanYuUpper = PartOfSpeech{Tag: "v2y-k", Buf: POSv2y_k, Label: "Nidan verb (upper class) with 'yu' ending (archaic)"}
-var VerbNidanZuLower = PartOfSpeech{Tag: "v2z-s", Buf: POSv2z_s, Label: "Nidan verb (lower class) with 'zu' ending (archaic)"}
-var VerbNuIrregular = PartOfSpeech{Tag: "vn", Buf: POSvn, Label: "irregular nu verb"}
-var VerbRuIrregular = PartOfSpeech{Tag: "vr", Buf: POSvr, Label: "irregular ru verb, plain form ends with -ri"}
-var VerbSu = PartOfSpeech{Tag: "vs-c", Buf: POSvs_c, Label: "su verb - precursor to the modern suru"}
-var VerbSuru = PartOfSpeech{Tag: "vs", Buf: POSvs, Label: "noun or participle which takes the aux. verb suru"}
-var VerbSuruIncluded = PartOfSpeech{Tag: "vs-i", Buf: POSvs_i, Label: "suru verb - included"}
-var VerbSuruSpecial = PartOfSpeech{Tag: "vs-s", Buf: POSvs_s, Label: "suru verb - special class"}
-var VerbUnspecified = PartOfSpeech{Tag: "v-unspec", Buf: POSv_unspec, Label: "verb unspecified"}
-var VerbYodanBu = PartOfSpeech{Tag: "v4b", Buf: POSv4b, Label: "Yodan verb with 'bu' ending (archaic)"}
-var VerbYodanGu = PartOfSpeech{Tag: "v4g", Buf: POSv4g, Label: "Yodan verb with 'gu' ending (archaic)"}
-var VerbYodanHuFu = PartOfSpeech{Tag: "v4h", Buf: POSv4h, Label: "Yodan verb with 'hu/fu' ending (archaic)"}
-var VerbYodanKu = PartOfSpeech{Tag: "v4k", Buf: POSv4k, Label: "Yodan verb with 'ku' ending (archaic)"}
-var VerbYodanMu = PartOfSpeech{Tag: "v4m", Buf: POSv4m, Label: "Yodan verb with 'mu' ending (archaic)"}
-var VerbYodanNu = PartOfSpeech{Tag: "v4n", Buf: POSv4n, Label: "Yodan verb with 'nu' ending (archaic)"}
-var VerbYodanRu = PartOfSpeech{Tag: "v4r", Buf: POSv4r, Label: "Yodan verb with 'ru' ending (archaic)"}
-var VerbYodanSu = PartOfSpeech{Tag: "v4s", Buf: POSv4s, Label: "Yodan verb with 'su' ending (archaic)"}
-var VerbYodanTsu = PartOfSpeech{Tag: "v4t", Buf: POSv4t, Label: "Yodan verb with 'tsu' ending (archaic)"}
+var AdjectivalPreNoun = PartOfSpeech{Buf: POSadj_pn, Label: "pre-noun adjectival (rentaishi)"}
+var AdjectiveKari = PartOfSpeech{Buf: POSadj_kari, Label: "'kari' adjective (archaic)"}
+var AdjectiveKu = PartOfSpeech{Buf: POSadj_ku, Label: "'ku' adjective (archaic)"}
+var AdjectiveNari = PartOfSpeech{Buf: POSadj_nari, Label: "archaic/formal form of na-adjective"}
+var AdjectiveNoun = PartOfSpeech{Buf: POSadj_na, Label: "adjectival nouns or quasi-adjectives (keiyodoshi)"}
+var AdjectiveShiku = PartOfSpeech{Buf: POSadj_shiku, Label: "'shiku' adjective (archaic)"}
+var AdjectiveTaru = PartOfSpeech{Buf: POSadj_t, Label: "'taru' adjective"}
+var AdjectiveYoiIi = PartOfSpeech{Buf: POSadj_ix, Label: "adjective (keiyoushi) - yoi/ii class"}
+var AdverbialNoun = PartOfSpeech{Buf: POSn_adv, Label: "adverbial noun (fukushitekimeishi)"}
+var AdverbTo = PartOfSpeech{Buf: POSadv_to, Label: "adverb taking the 'to' particle"}
+var NounNo = PartOfSpeech{Buf: POSadj_no, Label: "nouns which may take the genitive case particle 'no'"}
+var NounPrefix = PartOfSpeech{Buf: POSn_pref, Label: "noun, used as a prefix"}
+var NounSuffix = PartOfSpeech{Buf: POSn_suf, Label: "noun, used as a suffix"}
+var NounTemporal = PartOfSpeech{Buf: POSn_t, Label: "noun (temporal) (jisoumeishi)"}
+var NounVerbPrenominal = PartOfSpeech{Buf: POSadj_f, Label: "noun or verb acting prenominally"}
+var VerbGodanBu = PartOfSpeech{Buf: POSv5b, Label: "Godan verb with 'bu' ending"}
+var VerbGodanGu = PartOfSpeech{Buf: POSv5g, Label: "Godan verb with 'gu' ending"}
+var VerbGodanKu = PartOfSpeech{Buf: POSv5k, Label: "Godan verb with 'ku' ending"}
+var VerbGodanMu = PartOfSpeech{Buf: POSv5m, Label: "Godan verb with 'mu' ending"}
+var VerbGodanNu = PartOfSpeech{Buf: POSv5n, Label: "Godan verb with 'nu' ending"}
+var VerbGodanRu = PartOfSpeech{Buf: POSv5r, Label: "Godan verb with 'ru' ending"}
+var VerbGodanRuIrregular = PartOfSpeech{Buf: POSv5r_i, Label: "Godan verb with 'ru' ending (irregular verb)"}
+var VerbGodanSpecialAru = PartOfSpeech{Buf: POSv5aru, Label: "Godan verb - -aru special class"}
+var VerbGodanSpecialIkuYuku = PartOfSpeech{Buf: POSv5k_s, Label: "Godan verb - Iku/Yuku special class"}
+var VerbGodanSu = PartOfSpeech{Buf: POSv5s, Label: "Godan verb with 'su' ending"}
+var VerbGodanTsu = PartOfSpeech{Buf: POSv5t, Label: "Godan verb with 'tsu' ending"}
+var VerbGodanU = PartOfSpeech{Buf: POSv5u, Label: "Godan verb with 'u' ending"}
+var VerbGodanUruOldVerbOldFormOfEru = PartOfSpeech{Buf: POSv5uru, Label: "Godan verb - Uru old class verb (old form of Eru)"}
+var VerbGodanUSpecial = PartOfSpeech{Buf: POSv5u_s, Label: "Godan verb with 'u' ending (special class)"}
+var VerbIchidan = PartOfSpeech{Buf: POSv1, Label: "Ichidan verb"}
+var VerbIchidanSpecial = PartOfSpeech{Buf: POSv1_s, Label: "Ichidan verb - kureru special class"}
+var VerbIchidanZuru = PartOfSpeech{Buf: POSvz, Label: "Ichidan verb - zuru verb (alternative form of -jiru verbs)"}
+var VerbKuruSpecial = PartOfSpeech{Buf: POSvk, Label: "Kuru verb - special class"}
+var VerbNidanBuLower = PartOfSpeech{Buf: POSv2b_s, Label: "Nidan verb (lower class) with 'bu' ending (archaic)"}
+var VerbNidanBuUpper = PartOfSpeech{Buf: POSv2b_k, Label: "Nidan verb (upper class) with 'bu' ending (archaic)"}
+var VerbNidanDzuLower = PartOfSpeech{Buf: POSv2d_s, Label: "Nidan verb (lower class) with 'dzu' ending (archaic)"}
+var VerbNidanDzuUpper = PartOfSpeech{Buf: POSv2d_k, Label: "Nidan verb (upper class) with 'dzu' ending (archaic)"}
+var VerbNidanGuLower = PartOfSpeech{Buf: POSv2g_s, Label: "Nidan verb (lower class) with 'gu' ending (archaic)"}
+var VerbNidanGuUpper = PartOfSpeech{Buf: POSv2g_k, Label: "Nidan verb (upper class) with 'gu' ending (archaic)"}
+var VerbNidanHuFuLower = PartOfSpeech{Buf: POSv2h_s, Label: "Nidan verb (lower class) with 'hu/fu' ending (archaic)"}
+var VerbNidanHuFuUpper = PartOfSpeech{Buf: POSv2h_k, Label: "Nidan verb (upper class) with 'hu/fu' ending (archaic)"}
+var VerbNidanKuLower = PartOfSpeech{Buf: POSv2k_s, Label: "Nidan verb (lower class) with 'ku' ending (archaic)"}
+var VerbNidanKuUpper = PartOfSpeech{Buf: POSv2k_k, Label: "Nidan verb (upper class) with 'ku' ending (archaic)"}
+var VerbNidanMuLower = PartOfSpeech{Buf: POSv2m_s, Label: "Nidan verb (lower class) with 'mu' ending (archaic)"}
+var VerbNidanMuUpper = PartOfSpeech{Buf: POSv2m_k, Label: "Nidan verb (upper class) with 'mu' ending (archaic)"}
+var VerbNidanNuLower = PartOfSpeech{Buf: POSv2n_s, Label: "Nidan verb (lower class) with 'nu' ending (archaic)"}
+var VerbNidanRuLower = PartOfSpeech{Buf: POSv2r_s, Label: "Nidan verb (lower class) with 'ru' ending (archaic)"}
+var VerbNidanRuUpper = PartOfSpeech{Buf: POSv2r_k, Label: "Nidan verb (upper class) with 'ru' ending (archaic)"}
+var VerbNidanSuLower = PartOfSpeech{Buf: POSv2s_s, Label: "Nidan verb (lower class) with 'su' ending (archaic)"}
+var VerbNidanTsuLower = PartOfSpeech{Buf: POSv2t_s, Label: "Nidan verb (lower class) with 'tsu' ending (archaic)"}
+var VerbNidanTsuUpper = PartOfSpeech{Buf: POSv2t_k, Label: "Nidan verb (upper class) with 'tsu' ending (archaic)"}
+var VerbNidanU = PartOfSpeech{Buf: POSv2a_s, Label: "Nidan verb with 'u' ending (archaic)"}
+var VerbNidanUWeLower = PartOfSpeech{Buf: POSv2w_s, Label: "Nidan verb (lower class) with 'u' ending and 'we' conjugation (archaic)"}
+var VerbNidanYuLower = PartOfSpeech{Buf: POSv2y_s, Label: "Nidan verb (lower class) with 'yu' ending (archaic)"}
+var VerbNidanYuUpper = PartOfSpeech{Buf: POSv2y_k, Label: "Nidan verb (upper class) with 'yu' ending (archaic)"}
+var VerbNidanZuLower = PartOfSpeech{Buf: POSv2z_s, Label: "Nidan verb (lower class) with 'zu' ending (archaic)"}
+var VerbNuIrregular = PartOfSpeech{Buf: POSvn, Label: "irregular nu verb"}
+var VerbRuIrregular = PartOfSpeech{Buf: POSvr, Label: "irregular ru verb, plain form ends with -ri"}
+var VerbSu = PartOfSpeech{Buf: POSvs_c, Label: "su verb - precursor to the modern suru"}
+var VerbSuru = PartOfSpeech{Buf: POSvs, Label: "noun or participle which takes the aux. verb suru"}
+var VerbSuruIncluded = PartOfSpeech{Buf: POSvs_i, Label: "suru verb - included"}
+var VerbSuruSpecial = PartOfSpeech{Buf: POSvs_s, Label: "suru verb - special class"}
+var VerbUnspecified = PartOfSpeech{Buf: POSv_unspec, Label: "verb unspecified"}
+var VerbYodanBu = PartOfSpeech{Buf: POSv4b, Label: "Yodan verb with 'bu' ending (archaic)"}
+var VerbYodanGu = PartOfSpeech{Buf: POSv4g, Label: "Yodan verb with 'gu' ending (archaic)"}
+var VerbYodanHuFu = PartOfSpeech{Buf: POSv4h, Label: "Yodan verb with 'hu/fu' ending (archaic)"}
+var VerbYodanKu = PartOfSpeech{Buf: POSv4k, Label: "Yodan verb with 'ku' ending (archaic)"}
+var VerbYodanMu = PartOfSpeech{Buf: POSv4m, Label: "Yodan verb with 'mu' ending (archaic)"}
+var VerbYodanNu = PartOfSpeech{Buf: POSv4n, Label: "Yodan verb with 'nu' ending (archaic)"}
+var VerbYodanRu = PartOfSpeech{Buf: POSv4r, Label: "Yodan verb with 'ru' ending (archaic)"}
+var VerbYodanSu = PartOfSpeech{Buf: POSv4s, Label: "Yodan verb with 'su' ending (archaic)"}
+var VerbYodanTsu = PartOfSpeech{Buf: POSv4t, Label: "Yodan verb with 'tsu' ending (archaic)"}
 
 /* -------------------------------------------------------------------------- */
 /*                                Universal POS                               */
 /* -------------------------------------------------------------------------- */
 
-var Abbreviation = PartOfSpeech{Tag: "abbrev", Buf: POSabv, Label: "abbreviation"}
-var Adfix = PartOfSpeech{Tag: "adf", Buf: POSadf, Label: "adfix"}
-var Adjective = PartOfSpeech{Tag: "adj", Label: "adjective", Buf: POSadj}
-var AdjectivePhrase = PartOfSpeech{Tag: "phr_adj", Label: "adjective phrase", Buf: POSphr_adj}
-var Adverb = PartOfSpeech{Tag: "adv", Label: "adverb", Buf: POSadv}
-var AdverbialPhrase = PartOfSpeech{Tag: "phr_adv", Label: "adverbial phrase", Buf: POSphr_adv}
-var Affix = PartOfSpeech{Tag: "aff", Buf: POSaff, Label: "affix"}
-var Auxiliary = PartOfSpeech{Tag: "aux", Label: "auxiliary", Buf: POSaux}
-var AuxiliaryAdjective = PartOfSpeech{Tag: "aux-adj", Buf: POSaux_adj, Label: "auxiliary adjective"}
-var AuxiliaryVerb = PartOfSpeech{Tag: "aux-v", Buf: POSaux_v, Label: "auxiliary verb"}
-var Character = PartOfSpeech{Tag: "chr", Label: "character", Buf: POSchr}
-var Circumfix = PartOfSpeech{Tag: "crcf", Buf: POScf, Label: "circumfix"}
-var Conjunction = PartOfSpeech{Tag: "conj", Buf: POSconj, Label: "conjunction"}
-var CoordinatingConjunction = PartOfSpeech{Tag: "cconj", Buf: POSconj_c, Label: "coordinating conjunction"}
-var Copula = PartOfSpeech{Tag: "cop", Buf: POScop, Label: "copula"}
-var Counter = PartOfSpeech{Tag: "ctr", Buf: POSctr, Label: "counter"}
-var Determiner = PartOfSpeech{Tag: "det", Buf: POSdet, Label: "determiner"}
-var Expression = PartOfSpeech{Tag: "expr", Buf: POSexpr, Label: "expression"}
-var Infix = PartOfSpeech{Tag: "inf", Buf: POSinf, Label: "infix"}
-var Interfix = PartOfSpeech{Tag: "intf", Buf: POSintf, Label: "interfix"}
-var Interjection = PartOfSpeech{Tag: "intj", Buf: POSintj, Label: "interjection"}
-var IntransitiveVerb = PartOfSpeech{Tag: "vi", Buf: POSvi, Label: "intransitive verb"}
-var Name = PartOfSpeech{Tag: "name", Buf: POSname, Label: "name"}
-var Noun = PartOfSpeech{Tag: "n", Buf: POSn, Label: "noun"}
-var Numeric = PartOfSpeech{Tag: "num", Buf: POSnum, Label: "numeric"}
-var Particle = PartOfSpeech{Tag: "part", Buf: POSpart, Label: "particle"}
-var Phrase = PartOfSpeech{Tag: "phr", Buf: POSpart, Label: "phrase"}
-var Postposition = PartOfSpeech{Tag: "postp", Buf: POSpostp, Label: "postposition"}
-var Prefix = PartOfSpeech{Tag: "pref", Buf: POSpart, Label: "prefix"}
-var Preposition = PartOfSpeech{Tag: "prep", Buf: POSprep, Label: "preposition"}
-var PrepositionalPhrase = PartOfSpeech{Tag: "phr_prep", Label: "prepositional phrase", Buf: POSphr_adj}
-var Pronoun = PartOfSpeech{Tag: "pron", Buf: POSpron, Label: "pronoun"}
-var ProperNoun = PartOfSpeech{Tag: "propn", Buf: POSpropn, Label: "proper noun"}
-var Proverb = PartOfSpeech{Tag: "prov", Buf: POSprov, Label: "proverb"}
-var Punctuation = PartOfSpeech{Tag: "punc", Buf: POSpunc, Label: "punctuation"}
-var SubordinatingConjunction = PartOfSpeech{Tag: "conj_s", Buf: POSconj_s, Label: "subordinating conjunction"}
-var Suffix = PartOfSpeech{Tag: "suff", Buf: POSsuff, Label: "suffix"}
-var Symbol = PartOfSpeech{Tag: "sym", Buf: POSsym, Label: "symbol"}
-var TransitiveVerb = PartOfSpeech{Tag: "vt", Buf: POSvt, Label: "transitive verb"}
-var Unknown = PartOfSpeech{Tag: "un", Buf: POSun, Label: "unknown"}
-var Verb = PartOfSpeech{Tag: "v", Buf: POSv, Label: "verb"}
+var Abbreviation = PartOfSpeech{Buf: POSabv, Label: "abbreviation"}
+var Adfix = PartOfSpeech{Buf: POSadf, Label: "adfix"}
+var Adjective = PartOfSpeech{Buf: POSadj}
+var AdjectivePhrase = PartOfSpeech{Buf: POSphr_adj}
+var Adverb = PartOfSpeech{Buf: POSadv}
+var AdverbialPhrase = PartOfSpeech{Buf: POSphr_adv}
+var Affix = PartOfSpeech{Buf: POSaff, Label: "affix"}
+var Auxiliary = PartOfSpeech{Buf: POSaux}
+var AuxiliaryAdjective = PartOfSpeech{Buf: POSaux_adj, Label: "auxiliary adjective"}
+var AuxiliaryVerb = PartOfSpeech{Buf: POSaux_v, Label: "auxiliary verb"}
+var Character = PartOfSpeech{Buf: POSchr}
+var Circumfix = PartOfSpeech{Buf: POScf, Label: "circumfix"}
+var Conjunction = PartOfSpeech{Buf: POSconj, Label: "conjunction"}
+var CoordinatingConjunction = PartOfSpeech{Buf: POSconj_c, Label: "coordinating conjunction"}
+var Copula = PartOfSpeech{Buf: POScop, Label: "copula"}
+var Counter = PartOfSpeech{Buf: POSctr, Label: "counter"}
+var Determiner = PartOfSpeech{Buf: POSdet, Label: "determiner"}
+var Expression = PartOfSpeech{Buf: POSexpr, Label: "expression"}
+var Infix = PartOfSpeech{Buf: POSinf, Label: "infix"}
+var Interfix = PartOfSpeech{Buf: POSintf, Label: "interfix"}
+var Interjection = PartOfSpeech{Buf: POSintj, Label: "interjection"}
+var IntransitiveVerb = PartOfSpeech{Buf: POSvi, Label: "intransitive verb"}
+var Name = PartOfSpeech{Buf: POSname, Label: "name"}
+var Noun = PartOfSpeech{Buf: POSn, Label: "noun"}
+var Numeric = PartOfSpeech{Buf: POSnum, Label: "numeric"}
+var Particle = PartOfSpeech{Buf: POSpart, Label: "particle"}
+var Phrase = PartOfSpeech{Buf: POSpart, Label: "phrase"}
+var Postposition = PartOfSpeech{Buf: POSpostp, Label: "postposition"}
+var Prefix = PartOfSpeech{Buf: POSpart, Label: "prefix"}
+var Preposition = PartOfSpeech{Buf: POSprep, Label: "preposition"}
+var PrepositionalPhrase = PartOfSpeech{Buf: POSphr_adj}
+var Pronoun = PartOfSpeech{Buf: POSpron, Label: "pronoun"}
+var ProperNoun = PartOfSpeech{Buf: POSpropn, Label: "proper noun"}
+var Proverb = PartOfSpeech{Buf: POSprov, Label: "proverb"}
+var Punctuation = PartOfSpeech{Buf: POSpunc, Label: "punctuation"}
+var SubordinatingConjunction = PartOfSpeech{Buf: POSconj_s, Label: "subordinating conjunction"}
+var Suffix = PartOfSpeech{Buf: POSsuff, Label: "suffix"}
+var Symbol = PartOfSpeech{Buf: POSsym, Label: "symbol"}
+var TransitiveVerb = PartOfSpeech{Buf: POSvt, Label: "transitive verb"}
+var Unknown = PartOfSpeech{Buf: POSun, Label: "unknown"}
+var Verb = PartOfSpeech{Buf: POSv, Label: "verb"}
 
 var partsOfSpeech = []PartOfSpeech{
 
@@ -259,14 +263,14 @@ var posTagPartOfSpeechMap = (func() map[string]PartOfSpeech {
 	m := map[string]PartOfSpeech{}
 
 	for _, pos := range partsOfSpeech {
-		m[pos.Tag] = pos
+		m[pos.Tag()] = pos
 	}
 
 	return m
 })()
 
 func (p PartOfSpeech) MarshalText() ([]byte, error) {
-	return []byte(p.Tag), nil
+	return []byte(p.Tag()), nil
 }
 
 func (p *PartOfSpeech) UnmarshalText(text []byte) error {
@@ -276,7 +280,7 @@ func (p *PartOfSpeech) UnmarshalText(text []byte) error {
 }
 
 func (pos PartOfSpeech) MarshalXMLAttr(name xml.Name) (xml.Attr, error) {
-	return xml.Attr{Name: name, Value: pos.Tag}, nil
+	return xml.Attr{Name: name, Value: pos.Tag()}, nil
 }
 
 func (pos *PartOfSpeech) UnmarshalXMLAttr(attr xml.Attr) error {

--- a/lib/types/utils.go
+++ b/lib/types/utils.go
@@ -3,12 +3,17 @@ package types
 import (
 	"bytes"
 	"encoding/gob"
+	"strings"
 
 	"github.com/samber/lo"
 )
 
+func formatPOSTag(tag string) string {
+	return strings.ReplaceAll(tag, "_", "-")
+}
+
 func strToPartOfSpeech(str string) PartOfSpeech {
-	if val, ok := posTagPartOfSpeechMap[str]; ok {
+	if val, ok := posTagPartOfSpeechMap[formatPOSTag(str)]; ok {
 		return val
 	}
 

--- a/lib/utils/go.sum
+++ b/lib/utils/go.sum
@@ -1,7 +1,5 @@
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/gomarkdown/markdown v0.0.0-20231115200524-a660076da3fd h1:PppHBegd3uPZ3Y/Iax/2mlCFJm1w4Qf/zP1MdW4ju2o=
-github.com/gomarkdown/markdown v0.0.0-20231115200524-a660076da3fd/go.mod h1:JDGcbDT52eL4fju3sZ4TeHGsQwhG9nbDV21aMyhwPoA=
 github.com/gomarkdown/markdown v0.0.0-20231222211730-1d6d20845b47 h1:k4Tw0nt6lwro3Uin8eqoET7MDA4JnT8YgbCjc/g5E3k=
 github.com/gomarkdown/markdown v0.0.0-20231222211730-1d6d20845b47/go.mod h1:JDGcbDT52eL4fju3sZ4TeHGsQwhG9nbDV21aMyhwPoA=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=

--- a/test.xml
+++ b/test.xml
@@ -1,9 +1,0 @@
-<dictionary>
-  <entry term="A">
-    <ety description="Test">
-      <sense pos="abv">
-        <definition value="abbreviation for apple" />
-      </sense>
-    </ety>
-  </entry>
-</dictionary>

--- a/test.xml
+++ b/test.xml
@@ -1,0 +1,9 @@
+<dictionary>
+  <entry term="A">
+    <ety description="Test">
+      <sense pos="abv">
+        <definition value="abbreviation for apple" />
+      </sense>
+    </ety>
+  </entry>
+</dictionary>

--- a/xsd/go.mod
+++ b/xsd/go.mod
@@ -9,7 +9,7 @@ require (
 
 require (
 	github.com/TheOpenDictionary/odict/lib/utils v0.0.0-20231024210539-d4e83ae7bfdc // indirect
-	github.com/gomarkdown/markdown v0.0.0-20231115200524-a660076da3fd // indirect
+	github.com/gomarkdown/markdown v0.0.0-20231222211730-1d6d20845b47 // indirect
 	github.com/google/flatbuffers v23.5.26+incompatible // indirect
 	github.com/imdario/mergo v0.3.16 // indirect
 	github.com/samber/lo v1.39.0 // indirect

--- a/xsd/go.sum
+++ b/xsd/go.sum
@@ -6,7 +6,7 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-xmlfmt/xmlfmt v1.1.2 h1:Nea7b4icn8s57fTx1M5AI4qQT5HEM3rVUO8MuE6g80U=
 github.com/go-xmlfmt/xmlfmt v1.1.2/go.mod h1:aUCEOzzezBEjDBbFBoSiya/gduyIiWYRP6CnSFIV8AM=
-github.com/gomarkdown/markdown v0.0.0-20231115200524-a660076da3fd h1:PppHBegd3uPZ3Y/Iax/2mlCFJm1w4Qf/zP1MdW4ju2o=
+github.com/gomarkdown/markdown v0.0.0-20231222211730-1d6d20845b47 h1:k4Tw0nt6lwro3Uin8eqoET7MDA4JnT8YgbCjc/g5E3k=
 github.com/google/flatbuffers v23.5.26+incompatible h1:M9dgRyhJemaM4Sw8+66GHBu8ioaQmyPLg1b8VwK5WJg=
 github.com/google/flatbuffers v23.5.26+incompatible/go.mod h1:1AeVuKshWv4vARoZatz6mlQ0JxURH0Kv5+zNeJKJCa8=
 github.com/imdario/mergo v0.3.16 h1:wwQJbIsHYGMUyLSPrEq1CT16AhnhNJQ51+4fdHUnCl4=


### PR DESCRIPTION
While the PartOfSpeech struct had both a `Tag` and a `Buf` field, a stringified version of the `Buf` value from FlatBuffers was being used to locate the POS during lookups. If this differed from the `Tag` in the struct, then the POS wouldn't be found.

This PR updates `Tag` to be a computed value based on the stringified version of the FlatBuffer's enum (`Buf`) and replaces all underscores with dashes.

**Breaking change: the "abbrev" label has been changed to the shorter "abv" to match FlatBuffers**

Closes #551 