### PR TITLE
feat(python): add POS_TAGS

### DIFF
--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -8,6 +8,7 @@ mod utils;
 
 #[pymodule]
 fn theopendictionary(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    m.add("POS_TAGS", odict::POS_TAGS)?;
     m.add_class::<Dictionary>()?;
     m.add_class::<FormKind>()?;
     Ok(())


### PR DESCRIPTION
Hi, this is a small change, but it helps converting from dictionaries of other formats. For example, map pos not in this array to unknown instead of manual check.

Actually I'm working on updating https://github.com/TheOpenDictionary/converters, I think this change would also ease the work there.