### PR TITLE
Make mod semver public & implement partial order for SemanticVersion

### DIFF
--- a/lib/src/core/mod.rs
+++ b/lib/src/core/mod.rs
@@ -5,8 +5,7 @@ pub mod lookup;
 pub mod merge;
 pub mod preview;
 pub mod resolve;
-
-pub(crate) mod semver;
+pub mod semver;
 
 pub use io::DictionaryWriter;
 pub use io::{DictionaryFile, DictionaryReader};


### PR DESCRIPTION
This make it easier to implement custom version requirement logic. So I think it would be good to have this.