### PR TITLE
Fix Node CI mise Yarn setup

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -4,6 +4,7 @@ env:
   APP_NAME: node
   MACOSX_DEPLOYMENT_TARGET: "10.13"
   CARGO_INCREMENTAL: "1"
+  MISE_BACKENDS_YARN: "npm:@yarnpkg/cli-dist"
 "on":
   workflow_dispatch:
   push:
@@ -41,7 +42,7 @@ jobs:
       - name: Install clippy
         run: rustup component add clippy
       - name: Run lint
-        run: mise run --skip-tools //node:check
+        run: mise run --skip-tools --no-deps //node:check
   build:
     strategy:
       fail-fast: false
@@ -49,38 +50,38 @@ jobs:
         settings:
           - host: macos-15-intel
             target: x86_64-apple-darwin
-            build: mise run --skip-tools //node:build --target x86_64-apple-darwin
+            build: mise run --skip-tools --no-deps //node:build --target x86_64-apple-darwin
           - host: windows-latest
-            build: mise run --skip-tools //node:build --target x86_64-pc-windows-msvc
+            build: mise run --skip-tools --no-deps //node:build --target x86_64-pc-windows-msvc
             target: x86_64-pc-windows-msvc
           - host: windows-latest
-            build: mise run --skip-tools //node:build --target i686-pc-windows-msvc
+            build: mise run --skip-tools --no-deps //node:build --target i686-pc-windows-msvc
             target: i686-pc-windows-msvc
           - host: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             install_zig: true
-            build: mise run --skip-tools //node:build --target x86_64-unknown-linux-gnu -x
+            build: mise run --skip-tools --no-deps //node:build --target x86_64-unknown-linux-gnu -x
           - host: ubuntu-latest
             target: x86_64-unknown-linux-musl
             install_zig: true
-            build: mise run --skip-tools //node:build --target x86_64-unknown-linux-musl -x
+            build: mise run --skip-tools --no-deps //node:build --target x86_64-unknown-linux-musl -x
           - host: macos-latest
             target: aarch64-apple-darwin
-            build: mise run --skip-tools //node:build --target aarch64-apple-darwin
+            build: mise run --skip-tools --no-deps //node:build --target aarch64-apple-darwin
           - host: ubuntu-latest
             target: aarch64-unknown-linux-gnu
             install_zig: true
-            build: mise run --skip-tools //node:build --target aarch64-unknown-linux-gnu -x
+            build: mise run --skip-tools --no-deps //node:build --target aarch64-unknown-linux-gnu -x
           - host: ubuntu-latest
             target: aarch64-linux-android
-            build: mise run --skip-tools //node:build --target aarch64-linux-android
+            build: mise run --skip-tools --no-deps //node:build --target aarch64-linux-android
           - host: ubuntu-latest
             target: aarch64-unknown-linux-musl
             install_zig: true
-            build: mise run --skip-tools //node:build --target aarch64-unknown-linux-musl -x
+            build: mise run --skip-tools --no-deps //node:build --target aarch64-unknown-linux-musl -x
           - host: windows-latest
             target: aarch64-pc-windows-msvc
-            build: mise run --skip-tools //node:build --target aarch64-pc-windows-msvc
+            build: mise run --skip-tools --no-deps //node:build --target aarch64-pc-windows-msvc
           - host: ubuntu-latest
             target: wasm32-wasip1-threads
             setup: |
@@ -90,7 +91,7 @@ jobs:
               echo "CC_wasm32_wasip1_threads=${GITHUB_WORKSPACE}/wasi-sdk-32.0-x86_64-linux/bin/clang" >> $GITHUB_ENV
               echo "AR_wasm32_wasip1_threads=${GITHUB_WORKSPACE}/wasi-sdk-32.0-x86_64-linux/bin/llvm-ar" >> $GITHUB_ENV
               echo "CMAKE_BUILD_PARALLEL_LEVEL=2" >> $GITHUB_ENV
-            build: mise run --skip-tools //node:build:wasm
+            build: mise run --skip-tools --no-deps //node:build:wasm
     name: stable - ${{ matrix.settings.target }} - node@24
     runs-on: ${{ matrix.settings.host }}
     steps:
@@ -102,8 +103,6 @@ jobs:
           cache: true
           experimental: true
       - name: Install build tools
-        env:
-          MISE_BACKENDS_YARN: "npm:@yarnpkg/cli-dist"
         run: |
           mise --no-hooks install rust
           mise --no-hooks install -C node node yarn
@@ -111,8 +110,15 @@ jobs:
             mise --no-hooks install zig
           fi
         shell: bash
+      - name: Install dependencies
+        run: mise exec --no-deps -C node -- yarn install --immutable
+        shell: bash
+        env:
+          MISE_EXEC_AUTO_INSTALL: "false"
       - name: Add Rust target
-        run: rustup target add ${{ matrix.settings.target }}
+        run: mise exec --no-deps rust -- rustup target add ${{ matrix.settings.target }}
+        env:
+          MISE_EXEC_AUTO_INSTALL: "false"
       - name: Cache cargo
         uses: actions/cache@v5
         with:
@@ -225,7 +231,10 @@ jobs:
         run: mise --no-hooks install -C node node yarn
         env:
           MISE_NODE_VERSION: ${{ matrix.node }}
-          MISE_BACKENDS_YARN: "npm:@yarnpkg/cli-dist"
+      - name: Install dependencies
+        run: mise exec --no-deps -C node -- yarn install --immutable
+        env:
+          MISE_EXEC_AUTO_INSTALL: "false"
       - name: Download artifacts
         uses: actions/download-artifact@v8
         with:
@@ -235,7 +244,7 @@ jobs:
         run: ls -R .
         shell: bash
       - name: Test bindings
-        run: mise run --skip-tools //node:test
+        run: mise run --skip-tools --no-deps //node:test
   test-linux-binding:
     name: Test ${{ matrix.target }} - node@${{ matrix.node }}
     needs:
@@ -260,8 +269,6 @@ jobs:
           cache: true
           experimental: true
       - name: Install Node
-        env:
-          MISE_BACKENDS_YARN: "npm:@yarnpkg/cli-dist"
         run: mise --no-hooks install -C node node yarn
       - name: Output docker params
         id: docker
@@ -281,11 +288,12 @@ jobs:
             }
           " >> "$GITHUB_OUTPUT"
       - name: Install dependencies
-        working-directory: node
         run: |
-          yarn config set --json supportedArchitectures.cpu '["current", "arm64", "x64"]'
-          yarn config set --json supportedArchitectures.libc '["current", "musl", "gnu"]'
-          yarn install
+          mise exec --no-deps -C node -- yarn config set --json supportedArchitectures.cpu '["current", "arm64", "x64"]'
+          mise exec --no-deps -C node -- yarn config set --json supportedArchitectures.libc '["current", "musl", "gnu"]'
+          mise exec --no-deps -C node -- yarn install --immutable
+        env:
+          MISE_EXEC_AUTO_INSTALL: "false"
       - name: Download artifacts
         uses: actions/download-artifact@v8
         with:
@@ -300,7 +308,7 @@ jobs:
           image: ${{ steps.docker.outputs.IMAGE }}
           name: test-bindings-${{ matrix.target }}
           options: "-v ${{ github.workspace }}:${{ github.workspace }} -w ${{ github.workspace }} --platform ${{ steps.docker.outputs.PLATFORM }}"
-          args: sh -c "(command -v apk >/dev/null && apk add --no-cache ca-certificates) || (apt-get update -y && apt-get install -y ca-certificates); npm install -g @yarnpkg/cli-dist@4.17.0 --ignore-scripts && cd node && npm_config_optional=true yarn test"
+          args: sh -c "(command -v apk >/dev/null && apk add --no-cache ca-certificates) || (apt-get update -y && apt-get install -y ca-certificates); cd node && npm_config_optional=true npm exec --yes --package @yarnpkg/cli-dist@4.17.0 -- yarn test"
   test-wasi:
     name: Test WASI target
     needs:
@@ -315,14 +323,13 @@ jobs:
           cache: true
           experimental: true
       - name: Install Node
-        env:
-          MISE_BACKENDS_YARN: "npm:@yarnpkg/cli-dist"
         run: mise --no-hooks install -C node node yarn
       - name: Install dependencies
-        working-directory: node
         run: |
-          yarn config set supportedArchitectures.cpu "wasm32"
-          yarn install
+          mise exec --no-deps -C node -- yarn config set supportedArchitectures.cpu "wasm32"
+          mise exec --no-deps -C node -- yarn install --immutable
+        env:
+          MISE_EXEC_AUTO_INSTALL: "false"
       - name: Download artifacts
         uses: actions/download-artifact@v8
         with:
@@ -332,7 +339,7 @@ jobs:
         run: ls -R .
         shell: bash
       - name: Test bindings
-        run: mise run --skip-tools //node:test
+        run: mise run --skip-tools --no-deps //node:test
         env:
           NAPI_RS_FORCE_WASI: 1
   publish:
@@ -356,17 +363,19 @@ jobs:
           cache: true
           experimental: true
       - name: Install Node
-        env:
-          MISE_BACKENDS_YARN: "npm:@yarnpkg/cli-dist"
         run: mise --no-hooks install -C node node yarn
+      - name: Install dependencies
+        run: mise exec --no-deps -C node -- yarn install --immutable
+        env:
+          MISE_EXEC_AUTO_INSTALL: "false"
       - name: create npm dirs
-        run: mise run --skip-tools //node:create-dirs
+        run: mise run --skip-tools --no-deps //node:create-dirs
       - name: Download all artifacts
         uses: actions/download-artifact@v8
         with:
           path: ./node/artifacts
       - name: Move artifacts
-        run: mise run --skip-tools //node:artifacts
+        run: mise run --skip-tools --no-deps //node:artifacts
       - name: List packages
         run: ls -R ./npm
         shell: bash

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -206,8 +206,10 @@ jobs:
           experimental: true
       - name: Install Rust
         run: |
-          mise install rust
-          rustup target add ${{ matrix.platform.rust_target }}
+          mise --no-hooks install rust
+          mise exec --no-deps rust -- rustup target add ${{ matrix.platform.rust_target }}
+        env:
+          MISE_EXEC_AUTO_INSTALL: "false"
       - uses: actions/setup-python@v6
         with:
           python-version: 3.13


### PR DESCRIPTION
## Summary
- keep mise as the source of truth for Yarn via the npm cli-dist backend
- install Node/Yarn explicitly before Node workflow tasks
- run Node mise tasks with --no-deps after explicit yarn install steps to avoid recursive Yarn dependency preparation

## Verification
- ruby -e "require 'yaml'; YAML.load_file('.github/workflows/node.yml'); puts 'yaml ok'"
- git diff --check HEAD~1..HEAD
- MISE_BACKENDS_YARN='npm:@yarnpkg/cli-dist' mise exec --no-deps -C node -- yarn --version
- MISE_BACKENDS_YARN='npm:@yarnpkg/cli-dist' mise run --skip-tools --no-deps --dry-run //node:build --target x86_64-pc-windows-msvc
- MISE_BACKENDS_YARN='npm:@yarnpkg/cli-dist' mise run --skip-tools --no-deps --dry-run //node:test